### PR TITLE
Added support for getters and setters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ function extend(protoProps, staticProps) {
   // if supplied.
   if (protoProps) objectAssign(child.prototype, protoProps);
 
+  // Cpy getters and setters
+  Object.keys(protoProps).forEach(function(prop) {
+      var desc = Object.getOwnPropertyDescriptor(protoProps, prop);
+      if(desc.get || desc.set)
+        Object.defineProperty(child.prototype, prop, desc);
+  });
+  
   // Set a convenience property in case the parent's prototype is needed
   // later.
   child.__super__ = parent.prototype;

--- a/index.js
+++ b/index.js
@@ -40,15 +40,17 @@ function extend(protoProps, staticProps) {
 
   // Add prototype properties (instance properties) to the subclass,
   // if supplied.
-  if (protoProps) objectAssign(child.prototype, protoProps);
+  if (protoProps) {
+    objectAssign(child.prototype, protoProps);
 
-  // Cpy getters and setters
-  Object.keys(protoProps).forEach(function(prop) {
-      var desc = Object.getOwnPropertyDescriptor(protoProps, prop);
-      if(desc.get || desc.set)
-        Object.defineProperty(child.prototype, prop, desc);
-  });
-  
+    // Cpy getters and setters
+    Object.keys(protoProps).forEach(function(prop) {
+        var desc = Object.getOwnPropertyDescriptor(protoProps, prop);
+        if(desc.get || desc.set)
+          Object.defineProperty(child.prototype, prop, desc);
+    });
+  }
+    
   // Set a convenience property in case the parent's prototype is needed
   // later.
   child.__super__ = parent.prototype;


### PR DESCRIPTION
Property getters and setters like the syntax below weren't being extended as supposed to, I've added a few lines to check if there is a getter or setter then copy it to the child prototype, please review.

```
var obj = {
    innerValue: 1,

    get v() {
        return this.innerValue;
    },

    set v(newValue) {
        this.innerValue = newValue;
    }
};
```
